### PR TITLE
Add fn output rollout

### DIFF
--- a/hypatorch/core.py
+++ b/hypatorch/core.py
@@ -350,7 +350,21 @@ class Model( L.LightningModule ):
                     )
             
             sm_out_dict = { key: value for key, value in zip( expected_outputs, submodule_out ) }
-            x = { key_map: sm_out_dict[ key ] for key, key_map in output_key_map.items() }
+            #x = { key_map: sm_out_dict[ key ] for key, key_map in output_key_map.items() }
+            x = {}
+            for key, key_map in output_key_map.items():
+                if isinstance( key_map, str ):
+                    x[ key_map ] = sm_out_dict[ key ]
+                elif isinstance( key_map, List ) or isinstance( key_map, ListConfig ):
+                    for idx, km in enumerate( key_map ):
+                        x[ km ] = sm_out_dict[ key ][ idx ]
+                else:
+                    raise ValueError(
+                        f"""
+                        Error with output key mapping of {submodule_name}.
+                        Expected a string or a list, but got {type(key_map)}.
+                        """
+                        )
 
         return x
     

--- a/hypatorch/core.py
+++ b/hypatorch/core.py
@@ -441,7 +441,7 @@ class Model( L.LightningModule ):
 
             # Backward Pass if self.losses is not empty list
             opt = opts[ operation_idx ]
-            if self.losses:
+            if self.losses[ operation_name ]:
                 #opt = opts[ operation_idx ]
                 self._backward_pass(
                     opt = opt,


### PR DESCRIPTION
1) Adds the option to pass lists of keys to function output-key-maps to roll out iterable outputs.

2) Output dictionaries are now shared between operations. Thereby output keys of different operations must not overlap.

3) Fixes "if self.losses" condition in case of multi-operation mode