### PR TITLE
Model access in assessments

### DIFF
--- a/hypatorch/assessments.py
+++ b/hypatorch/assessments.py
@@ -54,9 +54,9 @@ class MaskedAssessment(torch.nn.Module):
 
     def forward(
             self,
-            inputs,
-            mask,
-            apply,
+            inputs: dict,
+            mask: torch.Tensor,
+            apply: List[str],
             ):
         if not apply:
             raise ValueError(
@@ -97,6 +97,7 @@ class HypaAssessment( torch.nn.Module ):
             weight = 1.0,
             apply: Optional[List[str]] = None,
             harmonizer_kwargs: Dict = {},
+            requires_model: bool = False,
             ):
         super().__init__()
         self.apply = apply
@@ -105,6 +106,7 @@ class HypaAssessment( torch.nn.Module ):
         self.inputs = inputs
         self.harmonize_inputs = harmonize_inputs
         self.masking = masking
+        self.requires_model = requires_model
         if masking is not None:
             self.assessment = MaskedAssessment(
                 unmasked_assessment=assessment,
@@ -119,8 +121,9 @@ class HypaAssessment( torch.nn.Module ):
     def forward(
             self,
             data_dict,
+            model
             ):
-        
+
         # Get inputs
         assessment_in = get_module_input(
             inputs = self.inputs,
@@ -146,6 +149,9 @@ class HypaAssessment( torch.nn.Module ):
             if self.masking is not None:
                 mask = h_out[-1]
         
+        if self.requires_model:
+            assessment_in['model'] = model
+
         if self.masking is not None:
             x = self.assessment(
                 inputs = assessment_in,

--- a/hypatorch/core.py
+++ b/hypatorch/core.py
@@ -236,6 +236,7 @@ class Model( L.LightningModule ):
             if fn.apply is None or mode in fn.apply:
                 y = fn(
                     data_dict = data_dict,
+                    model = self
                     )
                 x[ fn.name ] = y
 

--- a/hypatorch/utils.py
+++ b/hypatorch/utils.py
@@ -161,6 +161,10 @@ def get_module_input(
         data_dict: Dict,
         ):
     submodule_in = {}
+    
+    if not inputs:
+        return submodule_in
+    
     for k, v in inputs.items():
         if isinstance( v, List ) or isinstance( v, ListConfig):
             submodule_in[ k ] = [


### PR DESCRIPTION
Allows model weights to be accessed in the assessments by passing it as an appended argument if requires_model = True.
This allows to compute metrics or losses on the model weights directly.