### PR TITLE
Fix op output validation for expression/call returns

### DIFF
--- a/hypatorch/core.py
+++ b/hypatorch/core.py
@@ -399,14 +399,21 @@ class Model( torch.nn.Module ):
                     )
             
             sm_out_dict = { key: value for key, value in zip( expected_outputs, submodule_out ) }
-            #x = { key_map: sm_out_dict[ key ] for key, key_map in output_key_map.items() }
             x = {}
-            for key, key_map in output_key_map.items():
+            for position, ( key, key_map ) in enumerate( output_key_map.items() ):
+                # Name-based mapping when the returned value is a bare name that
+                # matches the configured key; otherwise fall back to positional
+                # mapping (declaration order), which covers expression returns
+                # such as `return torch.cat(...)`.
+                if key in sm_out_dict:
+                    value = sm_out_dict[ key ]
+                else:
+                    value = submodule_out[ position ]
                 if isinstance( key_map, str ):
-                    x[ key_map ] = sm_out_dict[ key ]
+                    x[ key_map ] = value
                 elif isinstance( key_map, List ) or isinstance( key_map, ListConfig ):
                     for idx, km in enumerate( key_map ):
-                        x[ km ] = sm_out_dict[ key ][ idx ]
+                        x[ km ] = value[ idx ]
                 else:
                     raise ValueError(
                         f"""

--- a/hypatorch/utils.py
+++ b/hypatorch/utils.py
@@ -1,5 +1,7 @@
 import torch
 import inspect
+import ast
+import textwrap
 from omegaconf import DictConfig
 from omegaconf import ListConfig
 
@@ -44,17 +46,22 @@ def get_output_variable_names(func):
             """
             )
     
-    return_part = return_part[1]
-    # Remove leading and trailing "(" and ")"
-    chars_to_replace = ["(", ")", "\n", " "]
-    for char in chars_to_replace:
-        return_part = return_part.replace(char, "")
-    # Remove trailing commas
-    return_part = return_part.rstrip(",")
-    # Split by commas and clean up the code
-    returned_variables = return_part.split(",")
-
-    returned_variables = [var.strip() for var in returned_variables]
+    # Parse the single return statement via AST so multi-value returns are
+    # counted correctly even when a returned value is a call/expression that
+    # itself contains commas (e.g. `return torch.cat(x, dim=d)` is ONE value,
+    # not two). Bare names are reported by name so explicit name-based output
+    # mapping keeps working; non-name expressions get positional placeholders,
+    # which core._run_submodule maps positionally in declaration order.
+    function_node = ast.parse(textwrap.dedent(source_lines)).body[0]
+    return_nodes = [n for n in ast.walk(function_node) if isinstance(n, ast.Return)]
+    return_value = return_nodes[-1].value
+    return_elements = (
+        return_value.elts if isinstance(return_value, ast.Tuple) else [return_value]
+    )
+    returned_variables = [
+        element.id if isinstance(element, ast.Name) else f"_output_{index}"
+        for index, element in enumerate(return_elements)
+    ]
     
     return returned_variables
 
@@ -123,7 +130,13 @@ def validate_io_keys(
             as required input_keys, but {input_keys} were given.
             """
             )
-    if not set( output_keys ).issubset( set( expected_outputs ) ):
+    output_names_match = set( output_keys ).issubset( set( expected_outputs ) )
+    # Expression returns (e.g. `return torch.cat(...)`) produce positional
+    # placeholders in expected_outputs that won't match the configured output
+    # keys; accept them as long as we don't request more outputs than were
+    # returned. core._run_submodule then maps those positionally, in order.
+    positional_ok = len( output_keys ) <= len( expected_outputs )
+    if not ( output_names_match or positional_ok ):
         raise ValueError(
             f"""
             {module_name} ({module_object_name}) expects {expected_outputs}

--- a/test/test_output_variable_names.py
+++ b/test/test_output_variable_names.py
@@ -1,0 +1,61 @@
+import torch
+
+from hypatorch.utils import get_output_variable_names, validate_io_keys
+
+
+class _Name(torch.nn.Module):
+    def forward(self, x):
+        return x
+
+
+class _Tuple(torch.nn.Module):
+    def forward(self, x, y):
+        return x, y
+
+
+class _Call(torch.nn.Module):
+    """Returns a single value built by a call whose args contain a comma."""
+
+    def __init__(self, dim=1):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x):
+        return torch.cat(x, dim=self.dim)
+
+
+class _Expr(torch.nn.Module):
+    def forward(self, x):
+        return x.detach()
+
+
+def test_bare_name_return():
+    assert get_output_variable_names(_Name().forward) == ["x"]
+
+
+def test_tuple_return_counts_each_element():
+    assert get_output_variable_names(_Tuple().forward) == ["x", "y"]
+
+
+def test_call_return_is_single_output():
+    # `torch.cat(x, dim=self.dim)` contains a comma but is ONE returned value;
+    # the old comma-splitting parser wrongly reported two.
+    assert get_output_variable_names(_Call().forward) == ["_output_0"]
+
+
+def test_expression_return_is_single_output():
+    assert get_output_variable_names(_Expr().forward) == ["_output_0"]
+
+
+def test_validate_accepts_configured_key_for_expression_return():
+    # An op may return an expression while the config labels the single output
+    # (e.g. {"x": "s_out"}). Validation must accept this (mapped positionally).
+    expected_outputs = get_output_variable_names(_Call().forward)
+    validate_io_keys(
+        module_name="concat",
+        module_object_name="_Call",
+        input_key_map={"x": "s_in"},
+        output_key_map={"x": "s_out"},
+        expected_inputs=(["x"], []),
+        expected_outputs=expected_outputs,
+    )


### PR DESCRIPTION
## Problem
`get_output_variable_names` parsed a module's `forward` return by stripping parens and splitting on commas. A single returned call/expression like `return torch.cat(x, dim=self.dim)` was therefore shredded into two fake outputs (`torch.catx` / `dim=self.dim`), and `validate_io_keys` then rejected the op:

```
concat (Concatenate) expects ['torch.catharmonized', 'dim=self.dim'] as output_keys, but ['x'] were given.
```

This breaks any op that returns an expression rather than a bare name — e.g. `Concatenate`, `Insert` (`return torch.cat(...)`), `Detach` (`return x.detach()`).

## Fix
- `get_output_variable_names`: parse the return via **AST** instead of string-splitting. Multi-value returns are counted correctly even when a value is a call/expression containing commas. Bare names are still reported by name (so name-based / subset output mapping is unchanged); non-name expressions get positional placeholders (`_output_{i}`).
- `core._run_submodule`: when a configured output key isn't a returned bare name, map **positionally** (declaration order). Name-based mapping is unchanged.
- `validate_io_keys`: accept the positional case when the number of configured outputs does not exceed the number returned.

## Tests
Adds `test/test_output_variable_names.py` (bare-name, tuple, call-with-comma, expression returns, positional validate). Full suite green: **33 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)