### PR TITLE
fix(train): chain to previous signal handler on SIGINT/SIGTERM

### DIFF
--- a/hypatorch/train.py
+++ b/hypatorch/train.py
@@ -550,17 +550,33 @@ class Trainer:
     def _signal_handler_context(self):
         previous_handlers = {}
 
-        def _handler(signum, _frame):
-            try:
-                signame = signal.Signals(signum).name
-            except ValueError:
-                signame = str(signum)
-            self._request_stop(f"signal:{signame}")
+        def _make_handler(previous):
+            def _handler(signum, frame):
+                try:
+                    signame = signal.Signals(signum).name
+                except ValueError:
+                    signame = str(signum)
+                self._request_stop(f"signal:{signame}")
+                # Chain to a previously-installed handler so outer layers can
+                # react immediately (e.g. finalize a tracking run) instead of
+                # waiting for the training loop to reach the next should_stop
+                # check -- which may never happen if we are blocked in setup or
+                # a long step. A previous handler that raises (e.g. to abort)
+                # unwinds through training; SIG_DFL/SIG_IGN are left untouched so
+                # the default graceful-stop behavior is preserved when nothing
+                # else is installed.
+                if callable(previous) and previous not in (
+                    signal.SIG_DFL,
+                    signal.SIG_IGN,
+                ):
+                    previous(signum, frame)
+
+            return _handler
 
         for sig in (signal.SIGINT, signal.SIGTERM):
             try:
                 previous_handlers[sig] = signal.getsignal(sig)
-                signal.signal(sig, _handler)
+                signal.signal(sig, _make_handler(previous_handlers[sig]))
             except (ValueError, OSError, RuntimeError):
                 continue
 

--- a/test/test_signal_handlers.py
+++ b/test/test_signal_handlers.py
@@ -1,0 +1,74 @@
+import signal
+import unittest
+
+import hypatorch
+
+
+class TestSignalHandlerChaining(unittest.TestCase):
+    """The training signal handler must request a graceful stop AND chain to a
+    previously-installed handler, so an outer layer (e.g. a tracking-run
+    finalizer) can react immediately instead of waiting for the next
+    should_stop check.
+    """
+
+    def _invoke_installed(self, signum):
+        handler = signal.getsignal(signum)
+        handler(signum, None)
+
+    def test_chains_to_previous_custom_handler_and_requests_stop(self):
+        trainer = hypatorch.Trainer()
+        trainer.should_stop = False
+        called = {}
+
+        def previous(signum, frame):  # noqa: ANN001
+            called["signum"] = signum
+
+        prev = signal.signal(signal.SIGTERM, previous)
+        try:
+            with trainer._signal_handler_context():
+                self._invoke_installed(signal.SIGTERM)
+        finally:
+            signal.signal(signal.SIGTERM, prev)
+
+        self.assertTrue(trainer.should_stop)
+        self.assertEqual(trainer._stop_reason, "signal:SIGTERM")
+        self.assertEqual(called.get("signum"), signal.SIGTERM)
+
+    def test_previous_handler_that_raises_propagates(self):
+        trainer = hypatorch.Trainer()
+
+        class _Abort(Exception):
+            pass
+
+        def previous(signum, frame):  # noqa: ANN001
+            raise _Abort()
+
+        prev = signal.signal(signal.SIGTERM, previous)
+        try:
+            with self.assertRaises(_Abort):
+                with trainer._signal_handler_context():
+                    self._invoke_installed(signal.SIGTERM)
+        finally:
+            signal.signal(signal.SIGTERM, prev)
+
+        # The graceful stop was still requested before propagating.
+        self.assertTrue(trainer.should_stop)
+
+    def test_default_handler_is_not_chained(self):
+        # With SIG_DFL installed (nothing custom), the handler must still request
+        # stop without trying to invoke the non-callable default (which is also
+        # how the graceful-only behavior is preserved).
+        trainer = hypatorch.Trainer()
+        trainer.should_stop = False
+        prev = signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        try:
+            with trainer._signal_handler_context():
+                self._invoke_installed(signal.SIGTERM)
+        finally:
+            signal.signal(signal.SIGTERM, prev)
+
+        self.assertTrue(trainer.should_stop)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`Trainer._signal_handler_context` installs a SIGINT/SIGTERM handler that sets `should_stop` (a cooperative stop, checked at loop/step boundaries) but **replaces any previously-installed handler without calling it**.

Consequences when a run is canceled (SIGTERM):
- If the process is blocked in setup or a long step, the `should_stop` check is never reached, so the graceful stop doesn't happen before the grace period expires → SIGKILL.
- Any handler an outer layer installed (e.g. to finalize a W&B/tracking run) is shadowed and never runs.

Observed downstream: `altavo-mltraining` installs a SIGTERM handler (in `wandb_run_context`) that raises to finalize the W&B run on JobPool cancel. Because this trainer overrode it, the W&B run was left stuck "running" after cancellation.

## Fix

The handler now **chains to the previously-installed handler** after requesting the graceful stop:
- A previous handler that raises (to abort immediately) unwinds through training — fast cancel, no waiting for the next `should_stop` check.
- `SIG_DFL` / `SIG_IGN` are left untouched, so the existing graceful-only behavior is preserved when nothing else is installed (e.g. interactive Ctrl+C).

## Tests

`test/test_signal_handlers.py`:
- chains to a custom previous handler and still sets `should_stop` / `_stop_reason`.
- a previous handler that raises propagates (with `should_stop` already set).
- `SIG_DFL` is not invoked (no crash; graceful behavior preserved).

Full training-loop suite (resume/checkpoint/train-mode) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)